### PR TITLE
Regenerated client from latest api spec yaml file to support GCP

### DIFF
--- a/.openapi-generator/FILES
+++ b/.openapi-generator/FILES
@@ -107,7 +107,6 @@ docs/V3UpdateClusterMetaRequest.md
 docs/V3UpdateClusterServersRequest.md
 docs/V3UpdateClusterSupportRequest.md
 docs/V3UpdateClusterSupportRequestSupportPackage.md
-git_push.sh
 go.mod
 go.sum
 model_allow_list_entry.go

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3370,6 +3370,7 @@ components:
       - destroy_succeeded
       - needs_cleanup
       - management_blocked
+      - upgrading
       type: string
     provider:
       enum:
@@ -3614,6 +3615,7 @@ components:
       enum:
       - GP3
       - IO2
+      - PD-SSD
       example: GP3
       type: string
     v3SupportPackageTimezones:
@@ -3640,9 +3642,19 @@ components:
       enum:
       - draft
       - deploying
+      - scaling
+      - upgrading
+      - rebalancing
+      - peering
       - destroying
       - healthy
       - degraded
+      - deploymentFailed
+      - scaleFailed
+      - upgradeFailed
+      - rebalanceFailed
+      - peeringFailed
+      - destroyFailed
       example: deploying
       type: string
     v3BucketRoles:
@@ -3767,18 +3779,17 @@ components:
         type:
           $ref: '#/components/schemas/v3StorageType'
         IOPS:
-          description: Min 3000 for GP3, 1000 if IO2. If storageType="GP3", max =
-            16000.  If storageType= "IO2", max= 64000
+          description: Required for GP3 and IO2. Min 3000 for GP3, 1000 if IO2. If
+            storageType="GP3", max = 16000. If storageType= "IO2", max= 64000
           example: 3000
           type: integer
         size:
-          description: Min 50Gb, max 16Tb
+          description: Min 50GB, max 16TB
           example: 50
           maximum: 16384
           minimum: 50
           type: integer
       required:
-      - IOPS
       - size
       - type
       type: object

--- a/docs/CloudStatus.md
+++ b/docs/CloudStatus.md
@@ -31,6 +31,8 @@
 
 * `MANAGEMENT_BLOCKED` (value: `"management_blocked"`)
 
+* `UPGRADING` (value: `"upgrading"`)
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/ClustersV3Api.md
+++ b/docs/ClustersV3Api.md
@@ -37,7 +37,7 @@ import (
 )
 
 func main() {
-    v3CreateClusterRequest := *openapiclient.NewV3CreateClusterRequest(openapiclient.v3Environment("hosted"), "Demo G2 Cluster", "99d9487a-235b-4b5f-b610-577a60edb911", *openapiclient.NewV3Place(true), []openapiclient.V3Servers{*openapiclient.NewV3Servers(int32(4), "m5.xlarge", []openapiclient.V3CouchbaseServices{openapiclient.v3CouchbaseServices("data")}, *openapiclient.NewV3ServersStorage(openapiclient.v3StorageType("GP3"), int32(3000), int32(50)))}, *openapiclient.NewV3SupportPackage(openapiclient.v3SupportPackageTimezones("ET"), openapiclient.v3SupportPackageType("Basic"))) // V3CreateClusterRequest |  (optional)
+    v3CreateClusterRequest := *openapiclient.NewV3CreateClusterRequest(openapiclient.v3Environment("hosted"), "Demo G2 Cluster", "99d9487a-235b-4b5f-b610-577a60edb911", *openapiclient.NewV3Place(true), []openapiclient.V3Servers{*openapiclient.NewV3Servers(int32(4), "m5.xlarge", []openapiclient.V3CouchbaseServices{openapiclient.v3CouchbaseServices("data")}, *openapiclient.NewV3ServersStorage(openapiclient.v3StorageType("GP3"), int32(50)))}, *openapiclient.NewV3SupportPackage(openapiclient.v3SupportPackageTimezones("ET"), openapiclient.v3SupportPackageType("Basic"))) // V3CreateClusterRequest |  (optional)
 
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
@@ -522,7 +522,7 @@ import (
 
 func main() {
     id := TODO // string | Cluster ID
-    v3UpdateClusterServersRequest := *openapiclient.NewV3UpdateClusterServersRequest([]openapiclient.V3Servers{*openapiclient.NewV3Servers(int32(4), "m5.xlarge", []openapiclient.V3CouchbaseServices{openapiclient.v3CouchbaseServices("data")}, *openapiclient.NewV3ServersStorage(openapiclient.v3StorageType("GP3"), int32(3000), int32(50)))}) // V3UpdateClusterServersRequest |  (optional)
+    v3UpdateClusterServersRequest := *openapiclient.NewV3UpdateClusterServersRequest([]openapiclient.V3Servers{*openapiclient.NewV3Servers(int32(4), "m5.xlarge", []openapiclient.V3CouchbaseServices{openapiclient.v3CouchbaseServices("data")}, *openapiclient.NewV3ServersStorage(openapiclient.v3StorageType("GP3"), int32(50)))}) // V3UpdateClusterServersRequest |  (optional)
 
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)

--- a/docs/V3ClusterStatus.md
+++ b/docs/V3ClusterStatus.md
@@ -7,11 +7,31 @@
 
 * `DEPLOYING` (value: `"deploying"`)
 
+* `SCALING` (value: `"scaling"`)
+
+* `UPGRADING` (value: `"upgrading"`)
+
+* `REBALANCING` (value: `"rebalancing"`)
+
+* `PEERING` (value: `"peering"`)
+
 * `DESTROYING` (value: `"destroying"`)
 
 * `HEALTHY` (value: `"healthy"`)
 
 * `DEGRADED` (value: `"degraded"`)
+
+* `DEPLOYMENT_FAILED` (value: `"deploymentFailed"`)
+
+* `SCALE_FAILED` (value: `"scaleFailed"`)
+
+* `UPGRADE_FAILED` (value: `"upgradeFailed"`)
+
+* `REBALANCE_FAILED` (value: `"rebalanceFailed"`)
+
+* `PEERING_FAILED` (value: `"peeringFailed"`)
+
+* `DESTROY_FAILED` (value: `"destroyFailed"`)
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/V3ServersStorage.md
+++ b/docs/V3ServersStorage.md
@@ -5,14 +5,14 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Type** | [**V3StorageType**](V3StorageType.md) |  | 
-**IOPS** | **int32** | Min 3000 for GP3, 1000 if IO2. If storageType&#x3D;\&quot;GP3\&quot;, max &#x3D; 16000.  If storageType&#x3D; \&quot;IO2\&quot;, max&#x3D; 64000 | 
-**Size** | **int32** | Min 50Gb, max 16Tb | 
+**IOPS** | Pointer to **int32** | Required for GP3 and IO2. Min 3000 for GP3, 1000 if IO2. If storageType&#x3D;\&quot;GP3\&quot;, max &#x3D; 16000. If storageType&#x3D; \&quot;IO2\&quot;, max&#x3D; 64000 | [optional] 
+**Size** | **int32** | Min 50GB, max 16TB | 
 
 ## Methods
 
 ### NewV3ServersStorage
 
-`func NewV3ServersStorage(type_ V3StorageType, iOPS int32, size int32, ) *V3ServersStorage`
+`func NewV3ServersStorage(type_ V3StorageType, size int32, ) *V3ServersStorage`
 
 NewV3ServersStorage instantiates a new V3ServersStorage object
 This constructor will assign default values to properties that have it defined,
@@ -66,6 +66,11 @@ and a boolean to check if the value has been set.
 
 SetIOPS sets IOPS field to given value.
 
+### HasIOPS
+
+`func (o *V3ServersStorage) HasIOPS() bool`
+
+HasIOPS returns a boolean if a field has been set.
 
 ### GetSize
 

--- a/docs/V3StorageType.md
+++ b/docs/V3StorageType.md
@@ -7,6 +7,8 @@
 
 * `IO2` (value: `"IO2"`)
 
+* `PD_SSD` (value: `"PD-SSD"`)
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/couchbasecloud/couchbase-capella-api-go-client
 
 go 1.13
 
-require (
-	github.com/couchbaselabs/couchbase-cloud-go-client v1.4.0
-	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99
-)
+require golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,6 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/couchbaselabs/couchbase-cloud-go-client v1.4.0 h1:S4xouMmbrKQdcTCS6yUjI/PLCPNLkUglEh3vtuHxmeg=
-github.com/couchbaselabs/couchbase-cloud-go-client v1.4.0/go.mod h1:7BNRWBnJJpY+jkPsHSkV4+OGSDOWN5lxnQdPOYitmN8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/model_cloud_status.go
+++ b/model_cloud_status.go
@@ -34,6 +34,7 @@ const (
 	CLOUDSTATUS_DESTROY_SUCCEEDED CloudStatus = "destroy_succeeded"
 	CLOUDSTATUS_NEEDS_CLEANUP CloudStatus = "needs_cleanup"
 	CLOUDSTATUS_MANAGEMENT_BLOCKED CloudStatus = "management_blocked"
+	CLOUDSTATUS_UPGRADING CloudStatus = "upgrading"
 )
 
 var allowedCloudStatusEnumValues = []CloudStatus{
@@ -51,6 +52,7 @@ var allowedCloudStatusEnumValues = []CloudStatus{
 	"destroy_succeeded",
 	"needs_cleanup",
 	"management_blocked",
+	"upgrading",
 }
 
 func (v *CloudStatus) UnmarshalJSON(src []byte) error {

--- a/model_v3_cluster_status.go
+++ b/model_v3_cluster_status.go
@@ -22,17 +22,37 @@ type V3ClusterStatus string
 const (
 	V3CLUSTERSTATUS_DRAFT V3ClusterStatus = "draft"
 	V3CLUSTERSTATUS_DEPLOYING V3ClusterStatus = "deploying"
+	V3CLUSTERSTATUS_SCALING V3ClusterStatus = "scaling"
+	V3CLUSTERSTATUS_UPGRADING V3ClusterStatus = "upgrading"
+	V3CLUSTERSTATUS_REBALANCING V3ClusterStatus = "rebalancing"
+	V3CLUSTERSTATUS_PEERING V3ClusterStatus = "peering"
 	V3CLUSTERSTATUS_DESTROYING V3ClusterStatus = "destroying"
 	V3CLUSTERSTATUS_HEALTHY V3ClusterStatus = "healthy"
 	V3CLUSTERSTATUS_DEGRADED V3ClusterStatus = "degraded"
+	V3CLUSTERSTATUS_DEPLOYMENT_FAILED V3ClusterStatus = "deploymentFailed"
+	V3CLUSTERSTATUS_SCALE_FAILED V3ClusterStatus = "scaleFailed"
+	V3CLUSTERSTATUS_UPGRADE_FAILED V3ClusterStatus = "upgradeFailed"
+	V3CLUSTERSTATUS_REBALANCE_FAILED V3ClusterStatus = "rebalanceFailed"
+	V3CLUSTERSTATUS_PEERING_FAILED V3ClusterStatus = "peeringFailed"
+	V3CLUSTERSTATUS_DESTROY_FAILED V3ClusterStatus = "destroyFailed"
 )
 
 var allowedV3ClusterStatusEnumValues = []V3ClusterStatus{
 	"draft",
 	"deploying",
+	"scaling",
+	"upgrading",
+	"rebalancing",
+	"peering",
 	"destroying",
 	"healthy",
 	"degraded",
+	"deploymentFailed",
+	"scaleFailed",
+	"upgradeFailed",
+	"rebalanceFailed",
+	"peeringFailed",
+	"destroyFailed",
 }
 
 func (v *V3ClusterStatus) UnmarshalJSON(src []byte) error {

--- a/model_v3_servers_storage.go
+++ b/model_v3_servers_storage.go
@@ -17,9 +17,9 @@ import (
 // V3ServersStorage struct for V3ServersStorage
 type V3ServersStorage struct {
 	Type V3StorageType `json:"type"`
-	// Min 3000 for GP3, 1000 if IO2. If storageType=\"GP3\", max = 16000.  If storageType= \"IO2\", max= 64000
-	IOPS int32 `json:"IOPS"`
-	// Min 50Gb, max 16Tb
+	// Required for GP3 and IO2. Min 3000 for GP3, 1000 if IO2. If storageType=\"GP3\", max = 16000. If storageType= \"IO2\", max= 64000
+	IOPS *int32 `json:"IOPS,omitempty"`
+	// Min 50GB, max 16TB
 	Size int32 `json:"size"`
 }
 
@@ -27,10 +27,9 @@ type V3ServersStorage struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewV3ServersStorage(type_ V3StorageType, iOPS int32, size int32) *V3ServersStorage {
+func NewV3ServersStorage(type_ V3StorageType, size int32) *V3ServersStorage {
 	this := V3ServersStorage{}
 	this.Type = type_
-	this.IOPS = iOPS
 	this.Size = size
 	return &this
 }
@@ -67,28 +66,36 @@ func (o *V3ServersStorage) SetType(v V3StorageType) {
 	o.Type = v
 }
 
-// GetIOPS returns the IOPS field value
+// GetIOPS returns the IOPS field value if set, zero value otherwise.
 func (o *V3ServersStorage) GetIOPS() int32 {
-	if o == nil {
+	if o == nil || o.IOPS == nil {
 		var ret int32
 		return ret
 	}
-
-	return o.IOPS
+	return *o.IOPS
 }
 
-// GetIOPSOk returns a tuple with the IOPS field value
+// GetIOPSOk returns a tuple with the IOPS field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *V3ServersStorage) GetIOPSOk() (*int32, bool) {
-	if o == nil  {
+	if o == nil || o.IOPS == nil {
 		return nil, false
 	}
-	return &o.IOPS, true
+	return o.IOPS, true
 }
 
-// SetIOPS sets field value
+// HasIOPS returns a boolean if a field has been set.
+func (o *V3ServersStorage) HasIOPS() bool {
+	if o != nil && o.IOPS != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetIOPS gets a reference to the given int32 and assigns it to the IOPS field.
 func (o *V3ServersStorage) SetIOPS(v int32) {
-	o.IOPS = v
+	o.IOPS = &v
 }
 
 // GetSize returns the Size field value
@@ -120,7 +127,7 @@ func (o V3ServersStorage) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["type"] = o.Type
 	}
-	if true {
+	if o.IOPS != nil {
 		toSerialize["IOPS"] = o.IOPS
 	}
 	if true {

--- a/model_v3_storage_type.go
+++ b/model_v3_storage_type.go
@@ -22,11 +22,13 @@ type V3StorageType string
 const (
 	V3STORAGETYPE_GP3 V3StorageType = "GP3"
 	V3STORAGETYPE_IO2 V3StorageType = "IO2"
+	V3STORAGETYPE_PD_SSD V3StorageType = "PD-SSD"
 )
 
 var allowedV3StorageTypeEnumValues = []V3StorageType{
 	"GP3",
 	"IO2",
+	"PD-SSD",
 }
 
 func (v *V3StorageType) UnmarshalJSON(src []byte) error {


### PR DESCRIPTION
Regenerated client to support creating GCP hosted clusters. This change is require in order to support managing GCP hosted clusters through the [Capella Terraform Provider](https://github.com/couchbasecloud/terraform-provider-couchbasecapella).

Client regenerated with the latest `openapi.yaml` file available from the Capella Public API documentation using the following command: 
```
openapi-generator generate -i ./openapi.yaml -g go -o ./ -t ./templates --package-name couchbasecapella -p enumClassPrefix=true 
```